### PR TITLE
Add SparklyPaper + fix typos

### DIFF
--- a/java/PLUGINS.md
+++ b/java/PLUGINS.md
@@ -130,13 +130,20 @@ This list contains Minecraft Java plugins server softwares.
 - **Plugins:** Minestom implementations
 
 ### [✂️ Slice](https://github.com/Cryptite/Slice)
-- **Version:** 1.17.1 - 1.22
+- **Version:** 1.17.1 - 1.20.2
 - **Author:** Cryptite
 - **Fork:** CraftBukkit --> Spigot --> Paper --> Slice
 - **Description:** A fork of Paper with additional patches (Note: nearly no information available, not recommended).
 - **Plugins:** Bukkit, Spigot, Paper
 
-- ### [🐙 Flying Squid](https://github.com/PrismarineJS/flying-squid)
+### [✨ SparklyPaper](https://github.com/SparklyPower/SparklyPaper)
+- **Version:** 1.20.2
+- **Author:** SparklyPower
+- **Fork:** CraftBukkit --> Spigot --> Paper --> SparklyPaper
+- **Description:** SparklyPower's Paper fork, making large servers snappier with high-performance optimizations and improvements! 
+- **Plugins:** Bukkit, Spigot, Paper
+- 
+### [🐙 Flying Squid](https://github.com/PrismarineJS/flying-squid)
 - **Version:** 1.8 - 1.16.1
 - **Author:** PrismarineJS
 - **Fork:** -

--- a/java/PLUGINS.md
+++ b/java/PLUGINS.md
@@ -140,7 +140,7 @@ This list contains Minecraft Java plugins server softwares.
 - **Version:** 1.20.2
 - **Author:** SparklyPower
 - **Fork:** CraftBukkit --> Spigot --> Paper --> SparklyPaper
-- **Description:** SparklyPower's Paper fork, making large servers snappier with high-performance optimizations and improvements! 
+- **Description:** SparklyPower's Paper fork, making large servers snappier with high-performance optimizations and improvements! (Note: in development, has features that may cause plugin incompatibility and unstability)
 - **Plugins:** Bukkit, Spigot, Paper
  
 ### [🐙 Flying Squid](https://github.com/PrismarineJS/flying-squid)

--- a/java/PLUGINS.md
+++ b/java/PLUGINS.md
@@ -142,7 +142,7 @@ This list contains Minecraft Java plugins server softwares.
 - **Fork:** CraftBukkit --> Spigot --> Paper --> SparklyPaper
 - **Description:** SparklyPower's Paper fork, making large servers snappier with high-performance optimizations and improvements! 
 - **Plugins:** Bukkit, Spigot, Paper
-- 
+ 
 ### [🐙 Flying Squid](https://github.com/PrismarineJS/flying-squid)
 - **Version:** 1.8 - 1.16.1
 - **Author:** PrismarineJS

--- a/java/PLUGINS.md
+++ b/java/PLUGINS.md
@@ -140,7 +140,7 @@ This list contains Minecraft Java plugins server softwares.
 - **Version:** 1.20.2
 - **Author:** SparklyPower
 - **Fork:** CraftBukkit --> Spigot --> Paper --> SparklyPaper
-- **Description:** SparklyPower's Paper fork, making large servers snappier with high-performance optimizations and improvements! (Note: in development, has features that may cause plugin incompatibility and unstability)
+- **Description:** SparklyPower's Paper fork, making large servers snappier with high-performance optimizations and improvements! (Note: only recommended for advanced users due to features that may break plugins and cause server instability)
 - **Plugins:** Bukkit, Spigot, Paper
  
 ### [🐙 Flying Squid](https://github.com/PrismarineJS/flying-squid)


### PR DESCRIPTION
Wasn't sure where to place my own fork on the list, so I placed after Slice. And let's see how far my fork will go before I deprecate it. (Maybe a `(Note: nearly no information available, not recommended)` or `(Note: in development, unstable, the developer doesn't recommend public usage)` would be needed tho, because while the fork is public, it was made for my own server so I don't really care if feature xyz breaks as long as I don't use that feature on my server)