### PR TITLE
fix weird encoding

### DIFF
--- a/bedrock/VANILLA.md
+++ b/bedrock/VANILLA.md
@@ -1,7 +1,7 @@
 # Minecraft Bedrock Vanilla Software
 This list contains Minecraft Bedrock vanilla server softwares.
 
-# ️️✔️ Active Development
+# ✔️ Active Development
 ### [🌍 Vanilla Bedrock (Bedrock Dedicated Server)](https://www.minecraft.net/en-us/download/server/bedrock)
 - **Author:** Mojang Studios (Microsoft)
 - **Fork:** -


### PR DESCRIPTION
I've just spent two hours troubleshooting why I wasn't able to parse this file in Python. Turns out, there's some crazy encoding going on in this single file.

```py
vanilla_bedrock = "# ️️✔️ Active Development"
anything_else   = "# ✔️ Active Development"
print(vanilla_bedrock == anything_else)

for char in vanilla_bedrock[:8]:
    print(f"'{char}': {ord(char)}")

for char in anything_else[:8]:
    print(f"'{char}': {ord(char)}")
```

```ls
False

'#': 35
' ': 32
'️': 65039   ⁉️
'️': 65039   ⁉️
'✔': 10004
'️': 65039
' ': 32
'A': 65

'#': 35
' ': 32
'✔': 10004
'️': 65039
' ': 32
'A': 65
'c': 99
't': 116
```